### PR TITLE
Return discussion for each subject

### DIFF
--- a/BLL/Interfaces/Subject.cs
+++ b/BLL/Interfaces/Subject.cs
@@ -12,7 +12,7 @@ namespace BLL.Interfaces
         Task<SubjectDTO> AddNewSubjectAsync(SubjectDTO Subject);
         Task DeleteAsync(int id);
         Task<SubjectDTO> GetByIdAsync(int id);
-        Task<List<SubjectDTO>> GetAllSubjectsAsync();
+        Task<List<GetSubjectDTO>> GetAllSubjectsAsync();
         Task<SubjectDTO> UpdateAsync(SubjectDTO Subject);
     }
 }

--- a/BLL/Interfaces/Subject.cs
+++ b/BLL/Interfaces/Subject.cs
@@ -11,7 +11,7 @@ namespace BLL.Interfaces
     {
         Task<SubjectDTO> AddNewSubjectAsync(SubjectDTO Subject);
         Task DeleteAsync(int id);
-        Task<SubjectDTO> GetByIdAsync(int id);
+        Task<GetByIDSubjectDTO> GetByIdAsync(int id);
         Task<List<GetSubjectDTO>> GetAllSubjectsAsync();
         Task<SubjectDTO> UpdateAsync(SubjectDTO Subject);
     }

--- a/BLL/Services/Subject.cs
+++ b/BLL/Services/Subject.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using DAL.Repositories;
 
 namespace BLL.Services
 {
@@ -58,12 +59,22 @@ namespace BLL.Services
             }
         }
 
-        public async Task<List<SubjectDTO>> GetAllSubjectsAsync()
+        public async Task<List<GetSubjectDTO>> GetAllSubjectsAsync()
         {
             try
             {
-                var answer= await SubjectRepository.GetAllAsync();
-                return mapper.Map<List<SubjectDTO>>(answer);    
+                var subjects = await SubjectRepository.GetAllAsync();
+
+                var subjectsWithCount = subjects.Select(subject =>
+                {
+                    var dto = mapper.Map<GetSubjectDTO>(subject); 
+                    dto.DiscussionsCount = SubjectRepository.CountOfDiscussionsForSubject(subject.Id);
+                    return dto;
+                }).ToList();
+
+
+                return subjectsWithCount;
+            
             }
             catch (Exception ex)
             {

--- a/BLL/Services/Subject.cs
+++ b/BLL/Services/Subject.cs
@@ -83,12 +83,18 @@ namespace BLL.Services
             }
         }
 
-        public async Task<SubjectDTO> GetByIdAsync(int id)
+        public async Task<GetByIDSubjectDTO> GetByIdAsync(int id)
         {
             try
             {
-                var answer= await SubjectRepository.GetByIdAsync(id);
-                return mapper.Map<SubjectDTO>(answer);
+                var answer = await SubjectRepository.GetByIdAsync(id);
+                var dto = mapper.Map<GetByIDSubjectDTO>(answer);
+
+                List<Discussion> discussions = await SubjectRepository.ListOfDiscussionsForSubject(id);
+                List<GetDiscussionDTO> discussionsDTO=mapper.Map<List<GetDiscussionDTO>>(discussions);
+                dto.Discussions =discussionsDTO ;
+
+                return dto;
             }
             catch (Exception ex)
             {

--- a/DAL/Interfaces/Subject.cs
+++ b/DAL/Interfaces/Subject.cs
@@ -14,5 +14,6 @@ namespace DAL.Interfaces
         Task<Subject> UpdateAsync(Subject entity);
         Task<Subject> AddAsync(Subject entity);
         Task DeleteAsync(int id);
+        int CountOfDiscussionsForSubject(int subjectId);
     }
 }

--- a/DAL/Interfaces/Subject.cs
+++ b/DAL/Interfaces/Subject.cs
@@ -15,5 +15,7 @@ namespace DAL.Interfaces
         Task<Subject> AddAsync(Subject entity);
         Task DeleteAsync(int id);
         int CountOfDiscussionsForSubject(int subjectId);
+        Task<List<Discussion>> ListOfDiscussionsForSubject(int subjectId);
+
     }
 }

--- a/DAL/Repositories/Subject.cs
+++ b/DAL/Repositories/Subject.cs
@@ -105,6 +105,15 @@ namespace DAL.Repositories
         {
             return context.Discussions.Count(d => d.SubjectId == subjectId);
         }
+       
+        public  Task<List<Discussion>> ListOfDiscussionsForSubject(int subjectId)
+        {
+            return  context.Discussions
+                                .Where(d => d.SubjectId == subjectId)
+                                .Include(d => d.User) 
+                                .Include(d => d.Comments) 
+                                .ToListAsync();
+        }
 
     }
 }

--- a/DAL/Repositories/Subject.cs
+++ b/DAL/Repositories/Subject.cs
@@ -101,5 +101,10 @@ namespace DAL.Repositories
                 throw;
             }
         }
+        public int CountOfDiscussionsForSubject(int subjectId)
+        {
+            return context.Discussions.Count(d => d.SubjectId == subjectId);
+        }
+
     }
 }

--- a/DTO/classes/GetByIDSubject.cs
+++ b/DTO/classes/GetByIDSubject.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DTO.classes
+{
+    public class GetByIDSubjectDTO:SubjectDTO
+    {
+        public List<GetDiscussionDTO> Discussions { get; set; }
+    }
+}

--- a/DTO/classes/GetSubject.cs
+++ b/DTO/classes/GetSubject.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DTO.classes
+{
+    public class GetSubjectDTO : SubjectDTO
+    {
+        public int DiscussionsCount { get; set; }
+    }
+}

--- a/DTO/classes/Mapper.cs
+++ b/DTO/classes/Mapper.cs
@@ -1,5 +1,6 @@
 ﻿using AutoMapper;
 using DAL.Models;
+using DAL.Repositories;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -44,6 +45,9 @@ namespace DTO.classes
                 .ForMember(dest => dest.UserId, opt => opt.MapFrom(src => src.UserId))
                 .ForMember(dest => dest.DiscussionId, opt => opt.MapFrom(src => src.DiscussionId))
                 .ForMember(dest => dest.Date, opt => opt.MapFrom(src => src.Date));
+
+            CreateMap<Subject, GetSubjectDTO>()
+                .ForMember(dest => dest.DiscussionsCount, opt => opt.Ignore()); 
 
 
 

--- a/DTO/classes/Mapper.cs
+++ b/DTO/classes/Mapper.cs
@@ -47,9 +47,10 @@ namespace DTO.classes
                 .ForMember(dest => dest.Date, opt => opt.MapFrom(src => src.Date));
 
             CreateMap<Subject, GetSubjectDTO>()
-                .ForMember(dest => dest.DiscussionsCount, opt => opt.Ignore()); 
+                .ForMember(dest => dest.DiscussionsCount, opt => opt.Ignore());
 
-
+            CreateMap<Subject, GetByIDSubjectDTO>()
+                .ForMember(dest => dest.Discussions, opt => opt.Ignore());
 
         }
     }


### PR DESCRIPTION
In this Pull Request, I made the following changes:

**New Classes:**

GetSubjectDTO:
Inherits from Subject and includes a new field count, which shows the number of discussions associated with each subject.

GetByIdSubjectDTO:
Inherits from Subject and includes a new field discussions, which holds a list of all discussions associated with the subject.

**Service Updates:**

The GetAllSubjectsAsync function was updated to also return the number of discussions (count) for each subject.
The GetByIdAsync function was updated to return the subject along with a list of all discussions associated with it.